### PR TITLE
Retry callback is now adjustable through bundle configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /phpunit.xml
 /.phpunit.result.cache
 /vendor/


### PR DESCRIPTION
This change will allow to assign a custom service to receive retry callbacks, instead of the default logger service of this bundle.