### PR TITLE
Allow Symfony 6 installation & support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,8 @@ $ composer require eugenganshorn/guzzle-bundle-retry-plugin
 ## Usage
 ### Enable bundle
 
-#### Symfony 2.x and 3.x
-Plugin will be activated/connected through bundle constructor in `app/AppKernel.php`, like this:
-
-``` php 
-new EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle([
-    new EugenGanshorn\Bundle\GuzzleBundleRetryPlugin\GuzzleBundleRetryPlugin(),
-])
-```
-
 #### Symfony 4
-The registration of bundles was changed in Symfony 4 and now you have to change `src/Kernel.php` to achieve the same functionality.  
+Plugin will be activated/connected through bundle constructor in `app/AppKernel.php`, like this:
 Find next lines:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ foreach ($contents as $class => $envs) {
     }
 }
 ```
+#### Symfony 5 & 6
+Override the `registerBundles` method in `src/Kernel.php` to connect the plugin to the bundle:
+
+```php
+public function registerBundles(): iterable
+{
+    $contents = require $this->getBundlesPath();
+    foreach ($contents as $class => $envs) {
+        if ($envs[$this->environment] ?? $envs['all'] ?? false) {
+            if ($class === EightPointsGuzzleBundle::class) {
+                yield new $class([
+                    new GuzzleBundleRetryPlugin(),
+                ]);
+            } else {
+                yield new $class();
+            }
+        }
+    }
+}
+```
 
 ### Basic configuration
 ``` yaml

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "eightpoints/guzzle-bundle": "^7.6|^8.0",
     "caseyamcl/guzzle_retry_middleware": "^2.2",
-    "symfony/dependency-injection": "~4.0|^5.0"
+    "symfony/dependency-injection": "^4.0|^5.0|^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1",


### PR DESCRIPTION
There is no code change in the library. This PR:

- Allow the installation through composer in Symfony 6 applications
- Update the installation documentation

Unit tests continue working. I've also tested it manually in a Symfony 6.2 app, and it works as expected.